### PR TITLE
UMLS Semantic Type tree

### DIFF
--- a/SciSpaCy/umls_semantic_type_tree.py
+++ b/SciSpaCy/umls_semantic_type_tree.py
@@ -1,0 +1,100 @@
+
+
+from typing import NamedTuple, List, Dict, Deque
+
+class SemanticTypeNode(NamedTuple):
+
+    type_id: str
+    full_name: str
+    children: List["SemanticTypeNode"]
+    level: int
+
+class UmlsSemanticTypeTree:
+    """
+    A utility class for manipulating the UMLS Semantic Type Hierarchy.
+    Designed to be constructed from a TSV file using `construct_umls_tree_from_tsv`.
+    """
+    def __init__(self, root: SemanticTypeNode) -> None:
+        children = self.get_children(root)
+        children.append(root)
+        # We'll store the nodes as a flattened list too, because
+        # we don't just care about the leaves of the tree - sometimes
+        # we'll need efficient access to intermediate nodes, and the tree
+        # is tiny anyway.
+        self.flat_nodes: List[SemanticTypeNode] = children
+        self.type_id_to_node = {node.type_id: node for node in self.flat_nodes}
+        self.depth = max([node.level for node in self.flat_nodes])
+
+    def get_node_from_id(self, type_id: str) -> SemanticTypeNode:
+        return self.type_id_to_node[type_id]
+
+    def get_canonical_name(self, type_id: str) -> str:
+        return self.type_id_to_node[type_id].full_name
+
+    def get_nodes_at_depth(self, level: int) -> List[SemanticTypeNode]:
+        """
+        Returns nodes at a particular depth in the tree.
+        """
+        return [node for node in self.flat_nodes if node.level == level]
+
+    def get_children(self, node: SemanticTypeNode) -> List[SemanticTypeNode]:
+        """
+        Recursively build up a flat list of all a node's children.
+        """
+        children = []
+        for child in node.children:
+            children.append(child)
+            children.extend(self.get_children(child))
+        return children
+
+    def get_collapsed_type_id_map_at_level(self, level: int) -> Dict[str, str]:
+        """
+        Constructs a label mapping from the original tree labels to a tree of a fixed depth,
+        collapsing labels greater than the depth specified to the closest parent which is
+        still present in the new fixed depth tree. This is effectively mapping to a _coarser_
+        label space.
+        """
+        new_type_id_map: Dict[str] = {k:k for k in self.type_id_to_node.keys()}
+        for node in self.get_nodes_at_depth(level):
+            for child in self.get_children(node):
+                new_type_id_map[child.type_id] = node.type_id
+        return new_type_id_map
+
+
+
+def construct_umls_tree_from_tsv(filepath: str) -> UmlsSemanticTypeTree:
+
+    """
+    Reads in a tsv file which is formatted as a depth first traversal of
+    a hierarchy tree, where nodes are of the format:
+
+    Name TAB UMLS Semantic Type TAB Tree Depth
+
+    Event	T051	1
+      Activity	T052	2
+        Behavior	T053	3
+          Social Behavior	T054	4
+          Individual Behavior	T055	4
+        Daily or Recreational Activity	T056	3
+    """
+    from collections import deque
+    node_stack = deque()
+    for line in open(filepath, "r"):
+        name, type_id, level = line.split("\t")
+        name = name.strip()
+        level = int(level.strip())
+        node = SemanticTypeNode(type_id, name, [], level)
+
+        node_stack.append(node)
+
+    def attach_children(node: SemanticTypeNode,
+                        stack: Deque[SemanticTypeNode]):
+        while stack and stack[0].level > node.level:
+            popped = stack.popleft()
+            attach_children(popped, stack)
+            node.children.append(popped)
+
+    first = node_stack.popleft()
+    attach_children(first, node_stack)
+
+    return UmlsSemanticTypeTree(first)

--- a/SciSpaCy/umls_semantic_type_tree.py
+++ b/SciSpaCy/umls_semantic_type_tree.py
@@ -1,12 +1,12 @@
 
 
-from typing import NamedTuple, List, Dict, Deque
+from typing import NamedTuple, List, Dict, Deque, Any
 
 class SemanticTypeNode(NamedTuple):
 
     type_id: str
     full_name: str
-    children: List["SemanticTypeNode"]
+    children: List[Any] # Mypy does not support nested types yet :(
     level: int
 
 class UmlsSemanticTypeTree:
@@ -54,7 +54,7 @@ class UmlsSemanticTypeTree:
         still present in the new fixed depth tree. This is effectively mapping to a _coarser_
         label space.
         """
-        new_type_id_map: Dict[str] = {k:k for k in self.type_id_to_node.keys()}
+        new_type_id_map: Dict[str, str] = {k:k for k in self.type_id_to_node.keys()}
         for node in self.get_nodes_at_depth(level):
             for child in self.get_children(node):
                 new_type_id_map[child.type_id] = node.type_id
@@ -78,12 +78,12 @@ def construct_umls_tree_from_tsv(filepath: str) -> UmlsSemanticTypeTree:
         Daily or Recreational Activity	T056	3
     """
     from collections import deque
-    node_stack = deque()
+    node_stack: Deque[SemanticTypeNode] = deque()
     for line in open(filepath, "r"):
         name, type_id, level = line.split("\t")
         name = name.strip()
-        level = int(level.strip())
-        node = SemanticTypeNode(type_id, name, [], level)
+        int_level = int(level.strip())
+        node = SemanticTypeNode(type_id, name, [], int_level)
 
         node_stack.append(node)
 

--- a/data/umls_semantic_type_tree.tsv
+++ b/data/umls_semantic_type_tree.tsv
@@ -1,0 +1,128 @@
+UnknownType	UnknownType	0
+Event	T051	1
+  Activity	T052	2
+    Behavior	T053	3
+      Social Behavior	T054	4
+      Individual Behavior	T055	4
+    Daily or Recreational Activity	T056	3
+    Occupational Activity	T057	3
+      Health Care Activity	T058	4
+        Laboratory Procedure	T059	5
+        Diagnostic Procedure	T060	5
+        Therapeutic or Preventive Procedure	T061	5
+      Research Activity	T062	4
+        Molecular Biology Research Technique	T063	5
+      Governmental or Regulatory Activity	T064	4
+      Educational Activity	T065	4
+    Machine Activity	T066	3
+  Phenomenon or Process	T067	2
+    Injury or Poisoning	T037	3
+    Human-caused Phenomenon or Process	T068	3
+      Environmental Effect of Humans	T069	4
+    Natural Phenomenon or Process	T070	3
+      Biologic Function	T038	4
+        Physiologic Function	T039	5
+          Organism Function	T040	6
+            Mental Process	T041	7
+          Organ or Tissue Function	T042	6
+          Cell Function	T043	6
+          Molecular Function	T044	6
+            Genetic Function	T045	7
+        Pathologic Function	T046	5
+          Disease or Syndrome	T047	6
+            Mental or Behavioral Dysfunction	T048	7
+            Neoplastic Process	T191	7
+          Cell or Molecular Dysfunction	T049	6
+          Experimental Model of Disease	T050	6
+Entity	T071	1
+  Physical Object	T072	2
+    Organism	T001	3
+      Virus	T005	4
+      Bacterium	T007	4
+      Archaeon	T194	4
+      Eukaryote	T204	4
+        Plant	T002	5
+        Fungus	T004	5
+        Animal	T008	5
+          Vertebrate	T010	6
+            Amphibian	T011	7
+            Bird	T012	7
+            Fish	T013	7
+            Reptile	T014	7
+            Mammal	T015	7
+              Human	T016	8
+    Anatomical Structure	T017	3
+      Embryonic Structure	T018	4
+      Fully Formed Anatomical Structure	T021	4
+        Body Part, Organ, or Organ Component	T023	5
+        Tissue	T024	5
+        Cell	T025	5
+        Cell Component	T026	5
+        Gene or Genome	T028	5
+      Anatomical Abnormality	T190	4
+        Congenital Abnormality	T019	5
+        Acquired Abnormality	T020	5
+    Manufactured Object	T073	3
+      Medical Device	T074	4
+        Drug Delivery Device	T203	5
+      Research Device	T075	4
+      Clinical Drug	T200	4
+    Substance	T167	3
+      Body Substance	T031	4
+      Chemical	T103	4
+        Chemical Viewed Structurally	T104	5
+          Organic Chemical	T109	6
+            Nucleic Acid, Nucleoside, or Nucleotide	T114	7
+            Amino Acid, Peptide, or Protein	T116	7
+          Element, Ion, or Isotope	T196	6
+          Inorganic Chemical	T197	6
+        Chemical Viewed Functionally	T120	5
+          Pharmacologic Substance	T121	6
+            Antibiotic	T195	7
+          Biomedical or Dental Material	T122	6
+          Biologically Active Substance	T123	6
+            Hormone	T125	7
+            Enzyme	T126	7
+            Vitamin	T127	7
+            Immunologic Factor	T129	7
+            Receptor	T192	7
+          Indicator, Reagent, or Diagnostic Aid	T130	6
+          Hazardous or Poisonous Substance	T131	6
+      Food	T168	4
+  Conceptual Entity	T077	2
+    Organism Attribute	T032	3
+      Clinical Attribute	T201	4
+    Finding	T033	3
+      Laboratory or Test Result	T034	4
+      Sign or Symptom	T184	4
+    Idea or Concept	T078	3
+      Temporal Concept	T079	4
+      Qualitative Concept	T080	4
+      Quantitative Concept	T081	4
+      Spatial Concept	T082	4
+        Body Location or Region	T029	5
+        Body Space or Junction	T030	5
+        Geographic Area	T083	5
+        Molecular Sequence	T085	5
+          Nucleotide Sequence	T086	6
+          Amino Acid Sequence	T087	6
+          Carbohydrate Sequence	T088	6
+      Functional Concept	T169	4
+        Body System	T022	5
+    Occupation or Discipline	T090	3
+      Biomedical Occupation or Discipline	T091	4
+    Organization	T092	3
+      Health Care Related Organization	T093	4
+      Professional Society	T094	4
+      Self-help or Relief Organization	T095	4
+    Group	T096	3
+      Professional or Occupational Group	T097	4
+      Population Group	T098	4
+      Family Group	T099	4
+      Age Group	T100	4
+      Patient or Disabled Group	T101	4
+    Group Attribute	T102	3
+    Intellectual Product	T170	3
+      Regulation or Law	T089	4
+      Classification	T185	4
+    ILanguage	T171	3

--- a/tests/fixtures/test_umls_tree.tsv
+++ b/tests/fixtures/test_umls_tree.tsv
@@ -1,0 +1,6 @@
+Event	T051	1
+  Activity	T052	2
+    Behavior	T053	3
+      Social Behavior	T054	4
+      Individual Behavior	T055	4
+    Daily or Recreational Activity	T056	3

--- a/tests/test_umls_semantic_type_tree.py
+++ b/tests/test_umls_semantic_type_tree.py
@@ -27,4 +27,4 @@ class TestUmlsSemanticTypeTree(unittest.TestCase):
                                'T055': 'T052',
                                'T056': 'T052',
                                'T051': 'T051'}
-        assert ["T052"] == self.tree.get_nodes_at_depth(2)
+        assert ["T052"] == [node.type_id for node in self.tree.get_nodes_at_depth(2)]

--- a/tests/test_umls_semantic_type_tree.py
+++ b/tests/test_umls_semantic_type_tree.py
@@ -1,0 +1,30 @@
+
+
+import unittest
+
+from SciSpaCy.umls_semantic_type_tree import construct_umls_tree_from_tsv
+
+class TestUmlsSemanticTypeTree(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.tree = construct_umls_tree_from_tsv("tests/fixtures/test_umls_tree.tsv")
+
+    def test_tree_can_be_read_from_file(self):
+
+        correct_names = ["Activity", "Behavior", "Social Behavior", "Individual Behavior",
+                         "Daily or Recreational Activity", "Event"]
+        correct_ids = ['T052', 'T053', 'T054', 'T055', 'T056', 'T051']
+        for node, name, umls_id in zip(self.tree.flat_nodes, correct_names, correct_ids):
+            assert node.full_name == name
+            assert node.type_id == umls_id
+
+    def test_tree_can_collapse_nodes(self):
+        new_mapping = self.tree.get_collapsed_type_id_map_at_level(2)
+        assert new_mapping == {'T052': 'T052',
+                               'T053': 'T052',
+                               'T054': 'T052',
+                               'T055': 'T052',
+                               'T056': 'T052',
+                               'T051': 'T051'}
+        assert ["T052"] == self.tree.get_nodes_at_depth(2)


### PR DESCRIPTION
Adds a UMLS Semantic Type tree. I'm going to use this to collapse the label space of the NER to see if it helps accuracy/F1.

Depth vs num labels:
```
1: 3
2: 7
3: 27
4: 67
5: 91
6: 110
7: 127
```
E.g for depth 3, this is the label space, which looks like a good trade off between granularity and not having a massive number of very similar labels:
```
Behavior
Group Attribute
Group
Natural Phenomenon or Process
Injury or Poisoning
Physical Object
Manufactured Object
Occupation or Discipline
Organization
Finding
UnknownType
Human-caused Phenomenon or Process
Substance
Phenomenon or Process
Event
Activity
ILanguage
Occupational Activity
Entity
Intellectual Product
Organism
Daily or Recreational Activity
Conceptual Entity
Organism Attribute
Idea or Concept
Anatomical Structure
Machine Activity
```
