### PR TITLE
add dump_to_spacy script

### DIFF
--- a/scripts/dump_to_spacy.py
+++ b/scripts/dump_to_spacy.py
@@ -1,0 +1,91 @@
+
+import os
+import sys
+from collections import defaultdict
+import argparse
+import json
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+import spacy_convert
+
+
+def generate_sentence(sentence):
+    (id_, word, tag, head, dep) = sentence
+    sentence = {}
+    tokens = []
+    for i, token_id in enumerate(id_):
+        # Note that this is not the same as the index
+        # due to elided words which were ignored.
+        token_id = token_id - 1
+        token = {}
+        token["id"] = token_id
+        token["orth"] = word[i]
+        token["tag"] = tag[i]
+        if head[i] == 0:
+            # The relative offset of the head to itself
+            # is zero
+            token["head"] = head[i]
+        else:
+            # What we are doing here is making the head
+            # of the token a relative offset.
+            token["head"] = (head[i] - 1) - token_id
+        token["dep"] = dep[i] if dep[i] != "root" else "ROOT"
+        tokens.append(token)
+    sentence["tokens"] = tokens
+    return sentence
+
+
+def create_doc(sentences, sentence_id: str):
+    doc = {}
+    paragraph = {}
+    doc["id"] = sentence_id
+    doc["paragraphs"] = []
+    paragraph["sentences"] = sentences
+    doc["paragraphs"].append(paragraph)
+    return doc
+
+
+def main(input_path: str, pmids_path: str, output_path: str):
+
+    pmids = []
+    with open(pmids_path) as pmids_fp:
+        line = pmids_fp.readline()
+        while line:
+            pmids.append(line.rstrip())
+            line = pmids_fp.readline()
+
+    # Create a dictionary mapping pubmed id to fully annotated docs.
+    docs = defaultdict(list)
+    for pubmed_id, sentence in zip(pmids, spacy_convert.get_dependency_annotations(input_path)):
+        docs[pubmed_id].append(sentence)
+    
+    formatted_docs = []
+    for pubmed_id, sentences in docs.items():
+        formatted_sentences = [generate_sentence(sent) for sent in sentences]
+        formatted_docs.append(create_doc(formatted_sentences, pubmed_id))
+
+    input_path = Path(input_path)
+    output_filename = input_path.parts[-1].replace(".conll", ".json")
+    output_filename = input_path.parts[-1].replace(".conllu", ".json")
+    output_file = Path(output_path) / output_filename
+    with output_file.open('w', encoding='utf-8') as f:
+        f.write(json.dumps(formatted_docs, indent=4))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--conll_path',
+        help="Path to the conll formatted data"
+    )
+    parser.add_argument(
+        '--output_path',
+        help="Path to the output directory"
+    )
+    parser.add_argument(
+        '--pubmed_ids',
+        help="Path to the pubmed_ids"
+    )
+    args = parser.parse_args()
+    main(args.conll_path, args.pubmed_ids, args.output_path)

--- a/scripts/dump_to_spacy.py
+++ b/scripts/dump_to_spacy.py
@@ -36,17 +36,19 @@ def generate_sentence(sentence):
     return sentence
 
 
-def create_doc(sentences, sentence_id: str):
+def create_doc(sentences, raw_text: str, sentence_id: str):
     doc = {}
     paragraph = {}
     doc["id"] = sentence_id
     doc["paragraphs"] = []
     paragraph["sentences"] = sentences
+    paragraph["raw"] = raw_text
     doc["paragraphs"].append(paragraph)
+    
     return doc
 
 
-def main(input_path: str, pmids_path: str, output_path: str):
+def main(input_path: str, pmids_path: str, output_path: str, raw_path: str):
 
     pmids = []
     with open(pmids_path) as pmids_fp:
@@ -62,8 +64,12 @@ def main(input_path: str, pmids_path: str, output_path: str):
     
     formatted_docs = []
     for pubmed_id, sentences in docs.items():
+
+        raw_sentences = open(os.path.join(raw_path, str(pubmed_id) + ".txt")).readlines()
+        raw_sentences = [sent.strip() for sent in raw_sentences]
+        document_text = " ".join(raw_sentences)
         formatted_sentences = [generate_sentence(sent) for sent in sentences]
-        formatted_docs.append(create_doc(formatted_sentences, pubmed_id))
+        formatted_docs.append(create_doc(formatted_sentences, document_text, pubmed_id))
 
     input_path = Path(input_path)
     output_filename = input_path.parts[-1].replace(".conll", ".json")
@@ -80,6 +86,10 @@ if __name__ == "__main__":
         help="Path to the conll formatted data"
     )
     parser.add_argument(
+    '--raw_path',
+    help="Path to the directory containing the raw abstracts."
+    )
+    parser.add_argument(
         '--output_path',
         help="Path to the output directory"
     )
@@ -88,4 +98,4 @@ if __name__ == "__main__":
         help="Path to the pubmed_ids"
     )
     args = parser.parse_args()
-    main(args.conll_path, args.pubmed_ids, args.output_path)
+    main(args.conll_path, args.pubmed_ids, args.output_path, args.raw_path)

--- a/scripts/spacy_convert.py
+++ b/scripts/spacy_convert.py
@@ -43,12 +43,12 @@ def get_dependency_annotations(path: str):
         # annotations, because they do confusing stuff like not
         # attaching to anything.
         annotation = [x for x in annotation if x["head"] is not None]
+        ids = [x["id"] for x in annotation]
         heads = [x["head"] for x in annotation]
         tags = [x["deprel"] for x in annotation]
         words = [x["form"] for x in annotation]
         pos_tags = [x["upostag"] for x in annotation]
-
-        yield (words, pos_tags, heads, tags)
+        yield (ids, words, pos_tags, heads, tags)
 
 def convert_abstracts_to_docs(conll_path, pmids_path, vocab_path):
     """Converts a conll file of abstracts to a doc and gold parse for


### PR DESCRIPTION
@danielkingai2 I think this script does the dumping to file in the right way for this version of spacy - I see what you mean about the differences between this version and later, that will be annoying to change

Edit: I tried converting the data and training a parser with `spacy train en -N train.json dev.json`, this seems to work nicely - 98.6 POS tag acc and 88.8 LAS after 3 epochs of training.