### PR TITLE
Base packages on spacy-nightly

### DIFF
--- a/data/bc5cdr_ner.json
+++ b/data/bc5cdr_ner.json
@@ -1,5 +1,6 @@
 {
   "lang":"en",
+  "parent_package":"spacy-nightly",
   "name":"ner_bc5cdr_md",
   "sources": ["BC5CDR", "OntoNotes 5", "Common Crawl", "GENIA 1.0"],
   "description":"Spacy Models for Biomedical Text.",

--- a/data/bionlp13cg_ner.json
+++ b/data/bionlp13cg_ner.json
@@ -1,5 +1,6 @@
 {
   "lang":"en",
+  "parent_package":"spacy-nightly",
   "name":"ner_bionlp13cg_md",
   "sources": ["BIONLP13CG", "OntoNotes 5", "Common Crawl", "GENIA 1.0"],
   "description":"Spacy Models for Biomedical Text.",

--- a/data/craft_ner.json
+++ b/data/craft_ner.json
@@ -1,5 +1,6 @@
 {
   "lang":"en",
+  "parent_package":"spacy-nightly",
   "name":"ner_craft_md",
   "sources": ["CRAFT", "OntoNotes 5", "Common Crawl", "GENIA 1.0"],
   "description":"Spacy Models for Biomedical Text.",

--- a/data/jnlpba_ner.json
+++ b/data/jnlpba_ner.json
@@ -1,5 +1,6 @@
 {
   "lang":"en",
+  "parent_package":"spacy-nightly",
   "name":"ner_jnlpba_md",
   "sources": ["JNLPBA", "OntoNotes 5", "Common Crawl", "GENIA 1.0"],
   "description":"Spacy Models for Biomedical Text.",

--- a/data/meta_medium.json
+++ b/data/meta_medium.json
@@ -1,5 +1,6 @@
 {
   "lang":"en",
+  "parent_package":"spacy-nightly",
   "name":"core_sci_md",
   "sources": ["OntoNotes 5", "Common Crawl", "GENIA 1.0"],
   "description":"Spacy Models for Biomedical Text.",

--- a/data/meta_small.json
+++ b/data/meta_small.json
@@ -1,5 +1,6 @@
 {
   "lang":"en",
+  "parent_package":"spacy-nightly",
   "name":"core_sci_sm",
   "sources": ["OntoNotes 5", "Common Crawl", "GENIA 1.0"],
   "description":"Spacy Models for Biomedical Text.",

--- a/scripts/create_model_package.sh
+++ b/scripts/create_model_package.sh
@@ -16,7 +16,7 @@ CURDIR=${PWD}
 
 mkdir -p dist
 
-spacy package ${MODEL} ${WORK}
+spacy package ${MODEL} ${WORK} --meta-path ${MODEL}/meta.json
 
 INITFILE=`find ${WORK} -name __init__.py`
 

--- a/scripts/create_model_package.sh
+++ b/scripts/create_model_package.sh
@@ -16,7 +16,7 @@ CURDIR=${PWD}
 
 mkdir -p dist
 
-spacy package ${MODEL} ${WORK} --meta-path ${MODEL}/meta.json
+spacy package ${MODEL} ${WORK}
 
 INITFILE=`find ${WORK} -name __init__.py`
 

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -6,6 +6,14 @@ SIZE=$1
 OUT_PATH=${2:-./build}
 MODEL_NAME=${3:-scispacy_model}
 
+if [ -d ${OUT_PATH}/${MODEL_NAME} ]; then 
+  read -p "Are you sure you wish to remove existing model directory ${OUT_PATH}/${MODEL_NAME} (yes to continue)?"
+  if [ "$REPLY" != "yes" ]; then
+    exit
+  fi
+  rm -Rf ${OUT_PATH}/${MODEL_NAME}; 
+fi
+
 if [[ -z "${SIZE}" ]]; then
   echo "Usage (run from base SciSpaCy repository):"
   echo "pipeline.sh <size> {small|medium} <build_directory> {default=./build} <model name> {default='scispacy_model'}"

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -7,11 +7,9 @@ OUT_PATH=${2:-./build}
 MODEL_NAME=${3:-scispacy_model}
 
 if [ -d ${OUT_PATH}/${MODEL_NAME} ]; then 
-  read -p "Are you sure you wish to remove existing model directory ${OUT_PATH}/${MODEL_NAME} (yes to continue)?"
-  if [ "$REPLY" != "yes" ]; then
-    exit
-  fi
-  rm -Rf ${OUT_PATH}/${MODEL_NAME}; 
+  echo "Build directory ${OUT_PATH}/${MODEL_NAME} already exists. Delete if you woud like to remake the package"
+  echo "Exiting"
+  exit
 fi
 
 if [[ -z "${SIZE}" ]]; then


### PR DESCRIPTION
I discovered that the pip install was broken because it was looking for spacy >= 2.1.0a6. If we are basing off of spacy-nightly, in order for pip install to work (spacy.load with the path to the model directory would still work), the metas need to have a parent_package key set to spacy-nightly.

Also, added check to remove directory if it already exists in pipeline.sh, because it seemed to not be recreating everything if you run pipeline.sh again after a successful build