### PR TITLE
Bump up version and provide support for spaCy 2.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 numpy
-spacy==2.0.18
+spacy>=2.0.18
 pandas
 awscli
 conllu


### PR DESCRIPTION
Bump up version in [requirements file](https://github.com/allenai/scispacy/blob/master/requirements.in)