### PR TITLE
Linking improvements

### DIFF
--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -368,7 +368,7 @@ if __name__ == "__main__":
      parser.add_argument(
              '--train',
              action="store_true",
-             help='Comma separated list of number of candidates.',
+             help='Fit the tfidf vectorizer and create the ANN index.',
      )
 
      args = parser.parse_args()

--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -288,7 +288,6 @@ def get_mention_text_and_ids(data: List[data_util.MedMentionsExample],
     mention_texts = []
     gold_umls_ids = []
 
-    # only loop over the dev examples for now because we don't have a trained model
     for example in data:
         for entity in example.entities:
             if entity.umls_id not in umls:
@@ -316,6 +315,7 @@ def main(medmentions_path: str, umls_path: str, model_path: str, ks: str, train:
     train_examples, dev_examples, test_examples = data_util.read_full_med_mentions(medmentions_path,
                                                                                    spacy_format=False)
 
+    # only loop over the dev examples for now because we don't have a trained model
     mention_texts, gold_umls_ids, missing_entity_ids = get_mention_text_and_ids(dev_examples,
                                                                                 umls_concept_dict_by_id)
 

--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -1,16 +1,51 @@
 """
 Linking using char-n-gram with approximate nearest neighbors.
+
+IDEAS:
+
+
+Compress index by deduplicating alias terms.
+In [72]: len(umls_concept_dict_by_id["C0006826"]["aliases"])
+Out[72]: 93
+
+In [73]: len(set(umls_concept_dict_by_id["C0006826"]["aliases"]))
+Out[73]: 43
+
+aliases
+mean, std, sum
+(1.2762667187768288, 3.6899733345584425, 3552930)
+set(aliases)
+mean, std, sum
+(1.08901462221689, 2.6062454661711856, 3031649)
+
+full precision
+9.49 s to load using scipy.sparse.load_npz("tmp.npz")
+file size: 686M
+
+half precision
+7.73 s to load using scipy.sparse.load_npz("tmp.npz")
+file size: 395MB
+
+
 """
+import os
+import os.path
+import sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.join(__file__, os.pardir))))
 from typing import List, Dict, Tuple
 import json
 import argparse
-import os.path
 import datetime
+from collections import defaultdict
+
+
+import scipy
 import numpy as np
 from joblib import dump, load
 from sklearn.feature_extraction.text import TfidfVectorizer
 import nmslib
 from nmslib.dist import FloatIndex
+
 from scispacy import data_util
 
 def load_umls_kb(umls_path: str) -> List[Dict]:
@@ -24,70 +59,94 @@ def load_umls_kb(umls_path: str) -> List[Dict]:
     print(f'Number of umls concepts: {len(umls_concept_list)}')
     return umls_concept_list
 
-def nmslis_knn_with_zero_vectors(vectors: np.ndarray, k: int, ann_index: FloatIndex) -> List[List]:
-    """ ann_index.knnQueryBatch crashes if any of the vectors is all zeros.
-    This function is a wrapper around `ann_index.knnQueryBatch` that solves this problem. It works as follows:
-    - remove empty vectors from `vectors`
-    - call `ann_index.knnQueryBatch` with the non-empty vectors only. This returns `neighbors`,
-    a list of list of neighbors. `len(neighbors)` equals the length of the non-empty vectors.
-    - extend the list `neighbors` with `None`s in place of empty vectors.
-    - return the extended list of neighbors
+class CandidateGenerator:
+
+    def __init__(self,
+                 ann_index: FloatIndex,
+                 tfidf_vectorizer: TfidfVectorizer,
+                 ann_concept_id_list: List[str]) -> None:
+
+        self.ann_index = ann_index
+        self.vectorizer = tfidf_vectorizer
+        self.ann_concept_id_list = ann_concept_id_list
+
+    def nmslib_knn_with_zero_vectors(self, vectors: np.ndarray, k: int) -> List[List]:
+        """ ann_index.knnQueryBatch crashes if any of the vectors is all zeros.
+        This function is a wrapper around `ann_index.knnQueryBatch` that solves this problem. It works as follows:
+        - remove empty vectors from `vectors`
+        - call `ann_index.knnQueryBatch` with the non-empty vectors only. This returns `neighbors`,
+        a list of list of neighbors. `len(neighbors)` equals the length of the non-empty vectors.
+        - extend the list `neighbors` with `None`s in place of empty vectors.
+        - return the extended list of neighbors
+        """
+        empty_vectors_boolean_flags = np.array(vectors.sum(axis=1) != 0).reshape(-1,)
+        empty_vectors_count = vectors.shape[0] - sum(empty_vectors_boolean_flags)
+        print(f'Number of empty vectors: {empty_vectors_count}')
+
+        # remove empty vectors before calling `ann_index.knnQueryBatch`
+        vectors = vectors[empty_vectors_boolean_flags]
+
+        # call `knnQueryBatch` to get neighbors
+        original_neighbours = self.ann_index.knnQueryBatch(vectors, k=k)
+        neighbors, distances = zip(*[(x[0].tolist(), x[1].tolist()) for x in original_neighbours])
+        neighbors = list(neighbors)
+        distances = list(distances)
+        # all an empty list in place for each empty vector to make sure len(extended_neighbors) == len(vectors)
+
+        # init extended_neighbors with a list of Nones
+        extended_neighbors = np.empty((len(empty_vectors_boolean_flags),), dtype=object)
+        extended_distances = np.empty((len(empty_vectors_boolean_flags),), dtype=object)
+
+        # neighbors need to be convected to an np.array of objects instead of ndarray of dimensions len(vectors)xk
+        # Solution: add a row to `neighbors` with any length other than k. This way, calling np.array(neighbors)
+        # returns an np.array of objects
+        neighbors.append([])
+        distances.append([])
+        # interleave `neighbors` and Nones in `extended_neighbors`
+        extended_neighbors[empty_vectors_boolean_flags] = np.array(neighbors)[:-1]
+        extended_distances[empty_vectors_boolean_flags] = np.array(distances)[:-1]
+
+        return extended_neighbors, extended_distances
+
+    def generate_candidates(self, mention_texts: List[str], k: int) -> List[List[int]]:
+        """
+        Given a list of mention texts, returns a list of candidate neighbors.
+
+        NOTE: Because we include canonical name aliases in the ann index, the list
+        of candidates returned will not necessarily be of length k for each candidate,
+        because we then map these to canonical ids only.
+        # TODO Mark: We should be able to use this signal somehow, maybe a voting system?
+        args:
+            mention_texts: list of mention texts
+            k: number of ann neighbors
+            ann_concept_id_list: a list of concept ids that the ann_index is referencing.
+        """
+        print(f'Generating candidates for {len(mention_texts)} mentions')
+        tfidfs = self.vectorizer.transform(mention_texts)
+        start_time = datetime.datetime.now()
+
+        # `ann_index.knnQueryBatch` crashes if one of the vectors is all zeros.
+        # `nmslib_knn_with_zero_vectors` is a wrapper around `ann_index.knnQueryBatch` that addresses this issue.
+        batch_neighbors, batch_distances = self.nmslib_knn_with_zero_vectors(tfidfs, k)
+        end_time = datetime.datetime.now()
+        total_time = end_time - start_time
+        print(f'Finding neighbors took {total_time.total_seconds()} seconds')
+        neighbors_by_concept_ids = []
+        for neighbors, distances in zip(batch_neighbors, batch_distances):
+            if neighbors is None:
+                neighbors = []
+
+            predicted_umls_concept_ids = defaultdict(list)
+            for n, d in zip(neighbors, distances):
+                predicted_umls_concept_ids[self.ann_concept_id_list[n]].append(d)
+            neighbors_by_concept_ids.append({**predicted_umls_concept_ids})
+            #neighbors_by_concept_ids.append({concept_id: np.mean(values)
+            #                                 for concept_id, values in predicted_umls_concept_ids.items()})
+        return neighbors_by_concept_ids
+
+def create_tfidf_ann_index(model_path: str, umls_concept_list: List) -> None:
     """
-    empty_vectors_boolean_flags = np.array(vectors.sum(axis=1) != 0).reshape(-1,)
-    empty_vectors_count = vectors.shape[0] - sum(empty_vectors_boolean_flags)
-    print(f'Number of empty vectors: {empty_vectors_count}')
-
-    # remove empty vectors before calling `ann_index.knnQueryBatch`
-    vectors = vectors[empty_vectors_boolean_flags]
-
-    # call `knnQueryBatch` to get neighbors
-    neighbors = [x[0].tolist() for x in ann_index.knnQueryBatch(vectors, k=k)]
-
-    # all an empty list in place for each empty vector to make sure len(extended_neighbors) == len(vectors)
-
-    # init extended_neighbors with a list of Nones
-    extended_neighbors = np.empty((len(empty_vectors_boolean_flags),), dtype=object)
-
-    # neighbors need to be convected to an np.array of objects instead of ndarray of dimensions len(vectors)xk
-    # Solution: add a row to `neighbors` with any length other than k. This way, calling np.array(neighbors)
-    # returns an np.array of objects
-    neighbors.append([])
-    # interleave `neighbors` and Nones in `extended_neighbors`
-    extended_neighbors[empty_vectors_boolean_flags] = np.array(neighbors)[:-1]
-
-    return extended_neighbors
-
-def generate_candidates(mention_texts: List[str], k: int, tfidf_vectorizer: TfidfVectorizer,
-                        ann_index: FloatIndex, ann_concept_id_list: List[int]) -> List[List[int]]:
-    """Given a list of mention texts, returns a list of candidate neighbors
-    args:
-        mention_texts: list of mention texts
-        k: number of ann neighbors
-        tfidf_vectorizer: text to vector
-        ann_index: approximate nearest neighbor index
-        ann_concept_id_list: a list of concept ids that the ann_index is referencing
-    """
-    print(f'Generating candidates for {len(mention_texts)} mentions')
-    tfidfs = tfidf_vectorizer.transform(mention_texts)
-    start_time = datetime.datetime.now()
-
-    # `ann_index.knnQueryBatch` crashes if one of the vectors is all zeros.
-    # `nmslis_knn_with_zero_vectors` is a wrapper around `ann_index.knnQueryBatch` that addresses this issue.
-    neighbors = nmslis_knn_with_zero_vectors(tfidfs, k, ann_index)
-    end_time = datetime.datetime.now()
-    total_time = end_time - start_time
-    print(f'Finding neighbors took {total_time.total_seconds()} seconds')
-    neighbors_by_concept_ids = []
-    for n in neighbors:
-        if n is None:
-            n = []
-        predicted_umls_concept_ids = set([ann_concept_id_list[x] for x in n])
-        neighbors_by_concept_ids.append(predicted_umls_concept_ids)
-    return neighbors_by_concept_ids
-
-def create_load_tfidf_ann_index(model_path: str, umls_concept_list: List) -> Tuple[List[int], TfidfVectorizer, FloatIndex]:
-    """
-    Build or load tfidf vectorizer and ann index
+    Build tfidf vectorizer and ann index.
     """
     tfidf_vectorizer_path = f'{model_path}/tfidf_vectorizer.joblib'
     ann_index_path = f'{model_path}/nmslib_index.bin'
@@ -105,65 +164,73 @@ def create_load_tfidf_ann_index(model_path: str, umls_concept_list: List) -> Tup
     num_threads = 60  # set based on the machine
     index_params = {'M': M, 'indexThreadQty': num_threads, 'efConstruction': efC, 'post' : 0}
 
+    print(f'No tfidf vectorizer on {tfidf_vectorizer_path} or ann index on {ann_index_path}')
+    uml_concept_ids = []
+    uml_concept_aliases = []
+    print('Collecting aliases ... ')
+    for i, concept in enumerate(umls_concept_list):
+        concept_id = concept['concept_id']
 
+        # TODO Add set call here, should compress index by 15%
+        concept_aliases = list(set(concept['aliases'])) + [concept['canonical_name']]
 
-    if not os.path.isfile(tfidf_vectorizer_path) or not os.path.isfile(ann_index_path):
-        print(f'No tfidf vectorizer on {tfidf_vectorizer_path} or ann index on {ann_index_path}')
-        uml_concept_ids = []
-        uml_concept_aliases = []
-        print('Collecting aliases ... ')
-        for i, concept in enumerate(umls_concept_list):
-            concept_id = concept['concept_id']
-            concept_aliases = concept['aliases'] + [concept['canonical_name']]
+        uml_concept_ids.extend([concept_id] * len(concept_aliases))
+        uml_concept_aliases.extend(concept_aliases)
 
-            uml_concept_ids.extend([concept_id] * len(concept_aliases))
-            uml_concept_aliases.extend(concept_aliases)
+        if i % 1000000 == 0 and i > 0:
+            print(f'Processed {i} or {len(umls_concept_list)} concepts')
 
-            if i % 1000000 == 0 and i > 0:
-                print(f'Processed {i} or {len(umls_concept_list)} concepts')
+    uml_concept_ids = np.array(uml_concept_ids)
+    uml_concept_aliases = np.array(uml_concept_aliases)
+    assert len(uml_concept_ids) == len(uml_concept_aliases)
 
-        uml_concept_ids = np.array(uml_concept_ids)
-        uml_concept_aliases = np.array(uml_concept_aliases)
-        assert len(uml_concept_ids) == len(uml_concept_aliases)
+    print(f'Fitting tfidf vectorizer on {len(uml_concept_aliases)} aliases')
+    tfidf_vectorizer = TfidfVectorizer(analyzer='char_wb', ngram_range=(3, 3), min_df=10, dtype=np.float16)
+    start_time = datetime.datetime.now()
+    uml_concept_alias_tfidfs = tfidf_vectorizer.fit_transform(uml_concept_aliases)
+    print(f'Saving tfidf vectorizer to {tfidf_vectorizer_path}')
+    dump(tfidf_vectorizer, tfidf_vectorizer_path)
+    end_time = datetime.datetime.now()
+    total_time = (end_time - start_time)
+    print(f'Fitting and saving vectorizer took {total_time.total_seconds()} seconds')
 
-        print(f'Fitting tfidf vectorizer on {len(uml_concept_aliases)} aliases')
-        tfidf_vectorizer = TfidfVectorizer(analyzer='char_wb', ngram_range=(3, 3), min_df=10, dtype=np.float32)
-        start_time = datetime.datetime.now()
-        uml_concept_alias_tfidfs = tfidf_vectorizer.fit_transform(uml_concept_aliases)
-        print(f'Saving tfidf vectorizer to {tfidf_vectorizer_path}')
-        dump(tfidf_vectorizer, tfidf_vectorizer_path)
-        end_time = datetime.datetime.now()
-        total_time = (end_time - start_time)
-        print(f'Fitting and saving vectorizer took {total_time.total_seconds()} seconds')
+    print(f'Finding empty (all zeros) tfidf vectors')
+    empty_tfidfs_boolean_flags = np.array(uml_concept_alias_tfidfs.sum(axis=1) != 0).reshape(-1,)
+    deleted_aliases = uml_concept_aliases[empty_tfidfs_boolean_flags == False]
+    number_of_non_empty_tfidfs = len(deleted_aliases)
+    total_number_of_tfidfs = uml_concept_alias_tfidfs.shape[0]
 
-        print(f'Finding empty (all zeros) tfidf vectors')
-        empty_tfidfs_boolean_flags = np.array(uml_concept_alias_tfidfs.sum(axis=1) != 0).reshape(-1,)
-        deleted_aliases = uml_concept_aliases[empty_tfidfs_boolean_flags == False]
-        number_of_non_empty_tfidfs = len(deleted_aliases)
-        total_number_of_tfidfs = uml_concept_alias_tfidfs.shape[0]
+    print(f'Deleting {number_of_non_empty_tfidfs}/{total_number_of_tfidfs} aliases because their tfidf is empty')
+    # remove empty tfidf vectors, otherwise nmslib will crash
+    uml_concept_ids = uml_concept_ids[empty_tfidfs_boolean_flags]
+    uml_concept_aliases = uml_concept_aliases[empty_tfidfs_boolean_flags]
+    uml_concept_alias_tfidfs = uml_concept_alias_tfidfs[empty_tfidfs_boolean_flags]
+    print(deleted_aliases)
 
-        print(f'Deleting {number_of_non_empty_tfidfs}/{total_number_of_tfidfs} aliases because their tfidf is empty')
-        # remove empty tfidf vectors, otherwise nmslib will crash
-        uml_concept_ids = uml_concept_ids[empty_tfidfs_boolean_flags]
-        uml_concept_aliases = uml_concept_aliases[empty_tfidfs_boolean_flags]
-        uml_concept_alias_tfidfs = uml_concept_alias_tfidfs[empty_tfidfs_boolean_flags]
-        print(deleted_aliases)
+    print('Saving list of concept ids and tfidfs vectors to {uml_concept_ids_path} and {tfidf_vectors_path}')
+    np.save(uml_concept_ids_path, uml_concept_ids)
+    scipy.sparse.save_npz(tfidf_vectors_path, uml_concept_alias_tfidfs)
+    assert len(uml_concept_ids) == len(uml_concept_aliases)
+    assert len(uml_concept_ids) == uml_concept_alias_tfidfs.shape[0]
 
-        print('Saving list of concept ids and tfidfs vectors to {uml_concept_ids_path} and {tfidf_vectors_path}')
-        np.save(uml_concept_ids_path, uml_concept_ids)
-        np.save(tfidf_vectors_path, uml_concept_alias_tfidfs)
-        assert len(uml_concept_ids) == len(uml_concept_aliases)
-        assert len(uml_concept_ids) == uml_concept_alias_tfidfs.shape[0]
+    print(f'Fitting ann index on {len(uml_concept_aliases)} aliases (takes 2 hours)')
+    start_time = datetime.datetime.now()
+    ann_index = nmslib.init(method='hnsw', space='cosinesimil_sparse', data_type=nmslib.DataType.SPARSE_VECTOR)
+    ann_index.addDataPointBatch(uml_concept_alias_tfidfs)
+    ann_index.createIndex(index_params, print_progress=True)
+    ann_index.saveIndex(ann_index_path)
+    end_time = datetime.datetime.now()
+    elapsed_time = end_time - start_time
+    print(f'Fitting ann index took {elapsed_time.total_seconds()} seconds')
 
-        print(f'Fitting ann index on {len(uml_concept_aliases)} aliases (takes 2 hours)')
-        start_time = datetime.datetime.now()
-        ann_index = nmslib.init(method='hnsw', space='cosinesimil_sparse', data_type=nmslib.DataType.SPARSE_VECTOR)
-        ann_index.addDataPointBatch(uml_concept_alias_tfidfs)
-        ann_index.createIndex(index_params, print_progress=True)
-        ann_index.saveIndex(ann_index_path)
-        end_time = datetime.datetime.now()
-        elapsed_time = end_time - start_time
-        print(f'Fitting ann index took {elapsed_time.total_seconds()} seconds')
+def load_tfidf_ann_index(model_path: str):
+
+    efS = 1000  # `S` for Search. This controls performance at query time. Maximum recommended value is 2000.
+                # It makes the query slow without significant gain in recall.
+    tfidf_vectorizer_path = f'{model_path}/tfidf_vectorizer.joblib'
+    ann_index_path = f'{model_path}/nmslib_index.bin'
+    tfidf_vectors_path = f'{model_path}/tfidf_vectors.npy'
+    uml_concept_ids_path = f'{model_path}/concept_ids.npy'
 
     start_time = datetime.datetime.now()
     print(f'Loading list of concepted ids from {uml_concept_ids_path}')
@@ -175,7 +242,7 @@ def create_load_tfidf_ann_index(model_path: str, umls_concept_list: List) -> Tup
         print(f'Tfidf vocab size: {len(tfidf_vectorizer.vocabulary_)}')
 
     print(f'Loading tfidf vectors from {tfidf_vectors_path}')
-    uml_concept_alias_tfidfs = np.load(tfidf_vectors_path).tolist()
+    uml_concept_alias_tfidfs = scipy.sparse.load_npz(tfidf_vectors_path).tolist()
 
     print(f'Loading ann index from {ann_index_path}')
     ann_index = nmslib.init(method='hnsw', space='cosinesimil_sparse', data_type=nmslib.DataType.SPARSE_VECTOR)
@@ -190,20 +257,9 @@ def create_load_tfidf_ann_index(model_path: str, umls_concept_list: List) -> Tup
     print(f'Loading concept ids, vectorizer, tfidf vectors and ann index took {total_time.total_seconds()} seconds')
     return uml_concept_ids, tfidf_vectorizer, ann_index
 
-def main(medmentions_path: str, umls_path: str, model_path: str, ks: str):
 
-    umls_concept_list = load_umls_kb(umls_path)
-    umls_concept_dict_by_id = dict((c['concept_id'], c) for c in umls_concept_list)
-
-    ann_concept_id_list, tfidf_vectorizer, ann_index = \
-            create_load_tfidf_ann_index(model_path, umls_concept_list)
-
-    print('Reading MedMentions ... ')
-    train_examples, dev_examples, test_examples = data_util.read_full_med_mentions(medmentions_path,
-                                                                                   spacy_format=False)
-
+def get_mention_text_and_ids(data, umls):
     missing_entity_ids = []  # entities in MedMentions but not in UMLS
-    found_entity_ids = []  # entities in MedMentions and in UMLS
 
     # don't care about context for now. Just do the processing based on mention text only
     # collect all the data in one list to use ann.knnQueryBatch which is a lot faster than
@@ -212,16 +268,35 @@ def main(medmentions_path: str, umls_path: str, model_path: str, ks: str):
     gold_umls_ids = []
 
     # only loop over the dev examples for now because we don't have a trained model
-    for example in dev_examples:
+    for example in data:
         for entity in example.entities:
-            if entity.umls_id not in umls_concept_dict_by_id:
+            if entity.umls_id not in umls:
                 missing_entity_ids.append(entity)  # the UMLS release doesn't contan all UMLS concepts
                 continue
-            found_entity_ids.append(entity)
 
             mention_texts.append(entity.mention_text)
             gold_umls_ids.append(entity.umls_id)
             continue
+
+    return mention_texts, gold_umls_ids, missing_entity_ids
+
+
+def main(medmentions_path: str, umls_path: str, model_path: str, ks: str, train: bool = False):
+
+    umls_concept_list = load_umls_kb(umls_path)
+    umls_concept_dict_by_id = dict((c['concept_id'], c) for c in umls_concept_list)
+
+    if train:
+        create_tfidf_ann_index(model_path, umls_concept_list)
+    ann_concept_id_list, tfidf_vectorizer, ann_index = load_tfidf_ann_index(model_path)
+
+    candidate_generator = CandidateGenerator(ann_index, tfidf_vectorizer, ann_concept_id_list)
+    print('Reading MedMentions ... ')
+    train_examples, dev_examples, test_examples = data_util.read_full_med_mentions(medmentions_path,
+                                                                                   spacy_format=False)
+
+    mention_texts, gold_umls_ids, missing_entity_ids = get_mention_text_and_ids(dev_examples,
+                                                                                umls_concept_dict_by_id)
 
     k_list = [int(k) for k in ks.split(',')]
     for k in k_list:
@@ -230,7 +305,7 @@ def main(medmentions_path: str, umls_path: str, model_path: str, ks: str):
         entity_wrong_links_count = 0  # number of wrongly linked entities
         entity_no_links_count = 0  # number of entities that are not linked
 
-        candidate_neighbor_ids = generate_candidates(mention_texts, k, tfidf_vectorizer, ann_index, ann_concept_id_list)
+        candidate_neighbor_ids = candidate_generator.generate_candidates(mention_texts, k)
 
         for mention_text, gold_umls_id, candidate_neighbor_ids in zip(mention_texts, gold_umls_ids, candidate_neighbor_ids):
             gold_canonical_name = umls_concept_dict_by_id[gold_umls_id]['canonical_name']
@@ -245,30 +320,36 @@ def main(medmentions_path: str, umls_path: str, model_path: str, ks: str):
 
 
         print(f'MedMentions entities not in UMLS: {len(missing_entity_ids)}')
-        print(f'MedMentions entities found in UMLS: {len(found_entity_ids)}')
+        print(f'MedMentions entities found in UMLS: {len(gold_umls_ids)}')
         print(f'K: {k}')
-        print('Gold concept in candidates: {0:.2f}%'.format(100 * entity_correct_links_count / len(found_entity_ids)))
-        print('Gold concept not in candidates: {0:.2f}%'.format(100 * entity_wrong_links_count / len(found_entity_ids)))
-        print('Candidate generation failed: {0:.2f}%'.format(100 * entity_no_links_count / len(found_entity_ids)))
+        print('Gold concept in candidates: {0:.2f}%'.format(100 * entity_correct_links_count / len(gold_umls_ids)))
+        print('Gold concept not in candidates: {0:.2f}%'.format(100 * entity_wrong_links_count / len(gold_umls_ids)))
+        print('Candidate generation failed: {0:.2f}%'.format(100 * entity_no_links_count / len(gold_umls_ids)))
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-            '--medmentions_path',
-            help='Path to the MedMentions dataset.'
-    )
-    parser.add_argument(
-            '--umls_path',
-            help='Path to the json UMLS release.'
-    )
-    parser.add_argument(
-            '--model_path',
-            help='Path to a directory with tfidf vectorizer and nmslib ann index.'
-    )
-    parser.add_argument(
-            '--ks',
-            help='Comma separated list of number of candidates.',
-    )
+    pass
+    # parser = argparse.ArgumentParser()
+    # parser.add_argument(
+    #         '--medmentions_path',
+    #         help='Path to the MedMentions dataset.'
+    # )
+    # parser.add_argument(
+    #         '--umls_path',
+    #         help='Path to the json UMLS release.'
+    # )
+    # parser.add_argument(
+    #         '--model_path',
+    #         help='Path to a directory with tfidf vectorizer and nmslib ann index.'
+    # )
+    # parser.add_argument(
+    #         '--ks',
+    #         help='Comma separated list of number of candidates.',
+    # )
+    # parser.add_argument(
+    #         '--train',
+    #         action="store_true",
+    #         help='Comma separated list of number of candidates.',
+    # )
 
-    args = parser.parse_args()
-    main(args.medmentions_path, args.umls_path, args.model_path, args.ks)
+    # args = parser.parse_args()
+    # main(args.medmentions_path, args.umls_path, args.model_path, args.ks, args.train)


### PR DESCRIPTION
Changes:

- Refactored to use a class, as eventually we'll want to maintain some state around the candidate generator.

- refactored `generate_candidates` to return a `List[Dict]` for each mention. The dictionary contains a mapping from `umls_canonical_id -> [list of cosine distances]`. note that the length of this dictionary for each mention may not be `k`, because we are doing NN search on the union of canonical ids and aliases, which will be mapped back to their canonical id.

- use `scipy.sparse.save_npz` and `numpy.float16` during serialisation as well as avoiding serializing arrays with `dtype=numpy.object`, resulting in the tfidf vectors reducing in size from 1.8G to 395MB.

- serialise the concept ids using json, not numpy: 193MB -> 67MB

- Deduplicating the aliases before computing the index means we reduce the size of the vectors + index by 15%.

