### PR TITLE
Add an evaluation option to use a spacy model for ner instead of gold mentions

### DIFF
--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -10,7 +10,7 @@ import json
 import argparse
 import datetime
 from collections import defaultdict
-
+from tqdm import tqdm
 
 import scipy
 import numpy as np
@@ -382,7 +382,7 @@ def eval_candidate_generation(examples: List[data_util.MedMentionExample],
             all_golds = []
             all_mentions = []
 
-            for i, example in enumerate(examples):
+            for i, example in tqdm(enumerate(examples), desc="Iterating over examples"):
                 entities = [entity for entity in example.entities if entity.umls_id in umls_concept_dict_by_id]
                 gold_umls_ids = [entity.umls_id for entity in entities]
                 mention_texts = [entity.mention_text for entity in entities]

--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -301,6 +301,13 @@ def get_mention_text_and_ids_by_doc(data: List[data_util.MedMentionExample],
                                     umls: Dict[str, Any]):
     """
     Returns a list of tuples containing a MedMentionExample and the texts and ids contianed in it
+
+    Parameters
+    ----------
+    data: List[data_util.MedMentionExample]
+        A list of MedMentionExamples being evaluated
+    umls: Dict[str, Any]
+        A dictionary of UMLS concepts
     """
     missing_entity_ids = []  # entities in MedMentions but not in UMLS
 
@@ -330,6 +337,21 @@ def eval_spacy_mentions(examples: List[data_util.MedMentionExample],
     """
     Evaluates candidate generation using mentions produced by a spacy model. This means that an entity is considered
     correct if that entity appears anywhere in the abstract
+
+    Parameters
+    ----------
+    examples: List[data_util.MedMentionExample]
+        An list of MedMentionExamples being evaluted
+    umls_concept_dict_by_id: Dict[str, Dict]
+        A dictionary of UMLS concepts
+    candidate_generator: CandidateGenerator
+        A CandidateGenerator instance for generating linking candidates for mentions
+    k_list: List[int]
+        A list of k values determining how many candidates are generated
+    thresholds: List[float]
+        A list of threshold values determining the cutoff score for candidates
+    spacy_model: str
+        The name of a spacy model to load and use for detecting mentions
     """
     nlp = spacy.load(spacy_model)
 
@@ -389,16 +411,29 @@ def eval_spacy_mentions(examples: List[data_util.MedMentionExample],
             print("Mean, std, min, max candidate ids: ", np.mean(num_candidates), np.std(num_candidates), np.min(num_candidates), np.max(num_candidates))
             print("Mean, std, min, max filtered candidate ids: ", np.mean(num_filtered_candidates), np.std(num_filtered_candidates), np.min(num_filtered_candidates), np.max(num_filtered_candidates))
 
-def eval_gold_mentions(dev_examples: List[data_util.MedMentionExample],
+def eval_gold_mentions(examples: List[data_util.MedMentionExample],
                        umls_concept_dict_by_id: Dict[str, Dict],
                        candidate_generator: CandidateGenerator,
                        k_list: List[int],
                        thresholds: List[float]):
     """
     Evaluate candidate generation using gold mentions. This evaluation is at the mention level.
+
+    Parameters
+    ----------
+    examples: List[data_util.MedMentionExample]
+        An list of MedMentionExamples being evaluted
+    umls_concept_dict_by_id: Dict[str, Dict]
+        A dictionary of UMLS concepts
+    candidate_generator: CandidateGenerator
+        A CandidateGenerator instance for generating linking candidates for mentions
+    k_list: List[int]
+        A list of k values determining how many candidates are generated
+    thresholds: List[float]
+        A list of threshold values determining the cutoff score for candidates
     """
     # only loop over the dev examples for now because we don't have a trained model
-    mention_texts, gold_umls_ids, missing_entity_ids = get_mention_text_and_ids(dev_examples,
+    mention_texts, gold_umls_ids, missing_entity_ids = get_mention_text_and_ids(examples,
                                                                                 umls_concept_dict_by_id)
 
     for k in k_list:

--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -382,7 +382,7 @@ def eval_candidate_generation(examples: List[data_util.MedMentionExample],
             all_golds = []
             all_mentions = []
 
-            for i, example in tqdm(enumerate(examples), desc="Iterating over examples"):
+            for i, example in tqdm(enumerate(examples), desc="Iterating over examples", total=len(examples)):
                 entities = [entity for entity in example.entities if entity.umls_id in umls_concept_dict_by_id]
                 gold_umls_ids = [entity.umls_id for entity in entities]
                 mention_texts = [entity.mention_text for entity in entities]

--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -361,6 +361,7 @@ def eval_candidate_generation(examples: List[data_util.MedMentionExample],
 
     if not use_gold_mentions:
         nlp = spacy.load(spacy_model)
+        docs = [nlp(example.text) for example in examples]
 
     for k in k_list:
         for threshold in thresholds:
@@ -381,7 +382,7 @@ def eval_candidate_generation(examples: List[data_util.MedMentionExample],
             all_golds = []
             all_mentions = []
 
-            for example in examples:
+            for i, example in enumerate(examples):
                 entities = [entity for entity in example.entities if entity.umls_id in umls_concept_dict_by_id]
                 gold_umls_ids = [entity.umls_id for entity in entities]
                 mention_texts = [entity.mention_text for entity in entities]
@@ -406,7 +407,7 @@ def eval_candidate_generation(examples: List[data_util.MedMentionExample],
                         else:
                             entity_wrong_links_count += 1
                 else:
-                    doc = nlp(example.text)
+                    doc = docs[i]
                     ner_entities = [ent for ent in doc.ents]
                     ner_mentions = [ent.text for ent in doc.ents]
 
@@ -432,9 +433,9 @@ def eval_candidate_generation(examples: List[data_util.MedMentionExample],
                     for gold_entity in entities:
                         span_from_doc = doc.char_span(gold_entity.start, gold_entity.end)
                         candidates = {}
-                        for i, predicted_entity in enumerate(ner_entities):
+                        for j, predicted_entity in enumerate(ner_entities):
                             if predicted_entity == span_from_doc:
-                                candidates = batch_candidate_neighbor_ids[i]
+                                candidates = batch_candidate_neighbor_ids[j]
                                 break
 
                         # Keep only canonical entities for which at least one mention has a score less than the threshold.

--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -336,7 +336,11 @@ def eval_candidate_generation(examples: List[data_util.MedMentionExample],
                               use_gold_mentions: bool,
                               spacy_model: str):
     """
-    Evaluate candidate generation using gold mentions. This evaluation is at the mention level.
+    Evaluate candidate generation using either gold mentions or spacy mentions.
+    The evaluation is done both at the mention level and at the document level. If the evaluation
+    is done with spacy mentions at the mention level, a pair is only considered correct if
+    both the mention and the entity are exactly correct. This could potentially be relaxed, but this 
+    matches the evaluation setup from the MedMentions paper.
 
     Parameters
     ----------


### PR DESCRIPTION
Evaluates candidate generation using a spacy model for ner instead of gold mentions. In this setting, an entity candidate is considered correct if that entity is in the gold entities for a given abstract. i.e. candidate entities are evaluated for correctness at the document level instead of the mention level, to avoid the complexity of trying to align mentions produced by the spacy model with the gold mentions.