### PR TITLE
Abbreviation api

### DIFF
--- a/scripts/linking.py
+++ b/scripts/linking.py
@@ -436,9 +436,8 @@ def get_mention_text_and_ids_by_doc(data: List[data_util.MedMentionExample],
         doc = nlp(example.text)
         abbreviations = {}
         if substitute_abbreviations:
-            for full, shorts in doc._.abbreviations:
-                for short in shorts:
-                    abbreviations[short] = full
+            for short in doc._.abbreviations:
+                abbreviations[short] = short._.long_form
 
         mention_texts = []
         predicted_mention_texts = []

--- a/tests/test_abbreviation_detection.py
+++ b/tests/test_abbreviation_detection.py
@@ -70,17 +70,18 @@ class TestAbbreviationDetector(unittest.TestCase):
         doc = self.nlp(self.text)
         assert doc._.abbreviations == []
         doc2 = self.detector(doc)
-        assert len(doc2._.abbreviations) == 2
+        assert len(doc2._.abbreviations) == 3
 
-        long, shorts = doc2._.abbreviations[0]
-        assert long.string == "Spinal and bulbar muscular atrophy "
-        assert len(shorts) == 2
-        assert {x.string for x in shorts} == {"SBMA", "SBMA "}
+        short = doc2._.abbreviations[0]
+        assert short._.long_form.string == "Spinal and bulbar muscular atrophy "
+        assert short.string == "SBMA "
+        short = doc2._.abbreviations[1]
+        assert short._.long_form.string == "Spinal and bulbar muscular atrophy "
+        assert short.string == "SBMA"
 
-        long, shorts = doc2._.abbreviations[1]
-        assert long.string == "androgen receptor "
-        assert len(shorts) == 1
-        assert shorts.pop().string == "AR"
+        short = doc2._.abbreviations[2]
+        assert short._.long_form.string == "androgen receptor "
+        assert short.string == "AR"
 
     def test_find(self):
         doc = self.nlp(self.text)

--- a/tests/test_abbreviation_detection.py
+++ b/tests/test_abbreviation_detection.py
@@ -72,16 +72,20 @@ class TestAbbreviationDetector(unittest.TestCase):
         doc2 = self.detector(doc)
         assert len(doc2._.abbreviations) == 3
 
-        short = doc2._.abbreviations[0]
-        assert short._.long_form.string == "Spinal and bulbar muscular atrophy "
-        assert short.string == "SBMA "
-        short = doc2._.abbreviations[1]
-        assert short._.long_form.string == "Spinal and bulbar muscular atrophy "
-        assert short.string == "SBMA"
+        correct  = set()
+        span = doc[33:34]
+        span._.long_form = doc[0:5]
+        correct.add(span)
+        span = doc[6:7]
+        span._.long_form = doc[0:5]
+        correct.add(span)
+        span = doc[29:30]
+        span._.long_form = doc[26:28]
+        correct.add(span)
+        correct_long = {x._.long_form for x in correct}
 
-        short = doc2._.abbreviations[2]
-        assert short._.long_form.string == "androgen receptor "
-        assert short.string == "AR"
+        assert set(doc2._.abbreviations) == correct
+        assert {x._.long_form for x in doc2._.abbreviations} == correct_long
 
     def test_find(self):
         doc = self.nlp(self.text)


### PR DESCRIPTION
Originally I set up the abbreviation component to return `LongForm, Set[ShortForm]` tuples, which was the wrong way to go about it because mostly, people will want to manipulate the short forms of the abbreviations. This way works much better.