### PR TITLE
Make use of all Concept Types

### DIFF
--- a/scispacy/data_util.py
+++ b/scispacy/data_util.py
@@ -39,9 +39,9 @@ def process_example(lines: List[str]) -> MedMentionExample:
     entities = []
     for entity_line in lines[2:]:
         _, start, end, mention, mention_type, umls_id = entity_line.split("\t")
-        mention_type = mention_type.split(",")[0]
-        entities.append(MedMentionEntity(int(start), int(end),
-                                         mention, mention_type, umls_id))
+        for mention_type_ in mention_type.split(","):
+            entities.append(MedMentionEntity(int(start), int(end),
+                                             mention, mention_type_, umls_id))
     return MedMentionExample(title, abstract, title + " " + abstract, pubmed_id, entities)
 
 def med_mentions_example_iterator(filename: str) -> Iterator[MedMentionExample]:


### PR DESCRIPTION
The 'type' field of MedMentions often includes several assignments, and you seem to have made the choice of only keeping the first type. The change I'm proposing creates additional entries ('entities') so that all type assignments are available for training, etc..
Quickly checking the difference in number of entities after this change, I'm seeing about 9% additional entities (in training set).

Just getting started with MedMentions, don't know if there may be some reason to just keep the first type, but if there isn't, this change may be of interest.