### PR TITLE
disable pipes when creating optimizers

### DIFF
--- a/scripts/train_ner.py
+++ b/scripts/train_ner.py
@@ -85,7 +85,9 @@ def train(model, train_data, dev_data, output_dir, n_iter):
                                    util.env_opt('batch_to', 32),
                                    util.env_opt('batch_compound', 1.001))
 
-    optimizer = nlp.begin_training()
+    with nlp.disable_pipes(*other_pipes):
+        optimizer = nlp.begin_training()
+
     best_epoch = 0
     best_f1 = 0
     for i in range(n_iter):

--- a/scripts/train_parser_and_tagger.py
+++ b/scripts/train_parser_and_tagger.py
@@ -92,11 +92,12 @@ def train_parser_and_tagger(train_json_path: str,
     n_train_words = train_corpus.count_train()
 
     other_pipes = [pipe for pipe in nlp.pipe_names if pipe not in  ['tagger', 'parser']]
-    if ontonotes_path:
-        optimizer = nlp.begin_training(lambda: itertools.chain(train_corpus.train_tuples, onto_train_corpus.train_tuples))
-    else:
-        optimizer = nlp.begin_training(lambda: train_corpus.train_tuples)
-    nlp._optimizer = None
+    with nlp.disable_pipes(*other_pipes):
+        if ontonotes_path:
+            optimizer = nlp.begin_training(lambda: itertools.chain(train_corpus.train_tuples, onto_train_corpus.train_tuples))
+        else:
+            optimizer = nlp.begin_training(lambda: train_corpus.train_tuples)
+        nlp._optimizer = None
 
     train_docs = train_corpus.train_docs(nlp)
     train_docs = list(train_docs)


### PR DESCRIPTION
Fixes #140 

The issue was that we were not disabling the other pipes when we called `nlp.begin_training()` so the parser pipe was getting `begin_training` called on it. It is possible that we don't need to call `begin_training` at all when we are starting from an existing model (see https://github.com/explosion/spaCy/blob/04113a844d9042f04c1fa0bc5830f11355b9b526/spacy/cli/train.py#L208-L213), but this seems to fix the problem.

The results of `spacy evaluate` on genia dev are:
POS       98.62
UAS       89.13
LAS       87.56

and the results of `train_ner --run_test` on med mentions dev are:
precision-untyped:               0.6776682259805685
recall-untyped:                  0.6628886010362695
f1-measure-untyped:              0.6701969409034441
