### PR TITLE
Add resolve abbreviations to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ nlp = spacy.load("en_core_sci_sm")
 # and load a large JSON file (the knowledge base). Be patient!
 # Thankfully it should be faster after the first time you use it, because
 # the downloads are cached.
-linker = UmlsEntityLinker()
+# NOTE: The resolve_abbreviations parameter is optional, and requires that
+# the AbbreviationDetector pipe has already been added to the pipeline. Adding
+# the AbbreviationDetector pipe and setting resolve_abbreviations to True means
+# that linking will only be performed on the long form of abbreviations.
+linker = UmlsEntityLinker(resolve_abbreviations=True)
 
 nlp.add_pipe(linker)
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ print(linker.umls.cui_to_entity[concept_id])
 
 #### Example Usage
 ```python
+import spacy
 import scispacy
 
 from scispacy.umls_linking import UmlsEntityLinker


### PR DESCRIPTION
@lucylw asked me if it was possible to resolve abbreviations prior to performing linking to prevent creating spurious candidates for acronyms. Since this feature already exists, I thought we should document it.