### PR TITLE
Fix abbreviation bug

### DIFF
--- a/scispacy/abbreviation.py
+++ b/scispacy/abbreviation.py
@@ -46,8 +46,10 @@ def find_abbreviation(long_form_candidate: Span,
                # to be the _starting_ character of a span.
                (short_index == 0 and long_index > 0 and long_form[long_index -1].isalnum())):
             long_index -= 1
-            if long_index < 0:
-                return short_form_candidate, None
+
+        if long_index < 0:
+            return short_form_candidate, None
+
         long_index -= 1
         short_index -= 1
 

--- a/tests/test_abbreviation_detection.py
+++ b/tests/test_abbreviation_detection.py
@@ -96,3 +96,12 @@ class TestAbbreviationDetector(unittest.TestCase):
 
         long, shorts = self.detector.find(doc[7:13], doc)
         assert shorts == set()
+
+    def test_issue_158(self):
+        text = "The PVO observations showed that the total transterminator flux "\
+               "was 23% of that at solar maximum and that the largest reductions in the "\
+               "number of ions transported antisunward occurred at the highest altitudes "\
+               "(Spenner et al., 1995)."
+        doc = self.nlp(text)
+        doc2 = self.detector(doc)
+        assert len(doc2._.abbreviations) == 0


### PR DESCRIPTION
One too many tabs in the copying of the implementation meant that if the first character of the long form matched not the first character of the short form, it would return a match even though not all short form characters were matched.

Fixes #158 