### PR TITLE
Pin scispacy to 2.1.x

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 numpy
-spacy>=2.1.3
+spacy>=2.1.3,<2.2
 pandas
 awscli
 conllu

--- a/scispacy/abbreviation.py
+++ b/scispacy/abbreviation.py
@@ -191,4 +191,4 @@ class AbbreviationDetector:
             # Clean up the global matcher.
             self.global_matcher.remove(key)
 
-        return [(k, v) for k, v in all_occurences.items()]
+        return list((k, v) for k, v in all_occurences.items())

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     license="Apache",
     install_requires=[
-        "spacy>=2.1.3",
+        "spacy>=2.1.3,<2.2",
         "awscli",
         "conllu",
         "numpy",


### PR DESCRIPTION
The current models are not compatible with spacy 2.2. Pinning the scispacy version until we can upgrade to 2.2 and release new models.