### PR TITLE
Add ontology code-linking to UmlsEntity (e.g., ICD10CM, Loinc, RxNorm, etc)

### DIFF
--- a/scispacy/umls_utils.py
+++ b/scispacy/umls_utils.py
@@ -15,6 +15,7 @@ class UmlsEntity(NamedTuple):
     canonical_name: str
     aliases: List[str]
     types: List[str]
+    codes: Dict[str, List[str]]
     definition: Optional[str] = None
 
     def __repr__(self):
@@ -148,6 +149,7 @@ def read_umls_concepts(meta_path: str, concept_details: Dict):
                     "concept_id": concept_id,
                     "aliases": [],
                     "types": [],
+                    "codes": defaultdict(list)
                 }
 
             concept_name = concept["STR"]
@@ -168,6 +170,7 @@ def read_umls_concepts(meta_path: str, concept_details: Dict):
                     "canonical_name"
                 ] = concept_name  # set as canonical name
 
+            concept_details[concept_id]['codes'][concept["SAB"]].append(concept["CODE"])
 
 def read_umls_types(meta_path: str, concept_details: Dict):
     """


### PR DESCRIPTION
This adds a dictionary of `codes` to each UmlsEntity, allowing expressions like: `linker.umls.cui_to_entity[cui].codes['ICD10CM']` to get a list of ICD10CM codes. The code key/values are defined by the SAB/CODE columns of MRCONSO.

Example:

```
    {
        "concept_id": "C0000005",
        "aliases": [
            "(131)I-MAA"
        ],
        "types": [
            "T116"
        ],
        "codes": { // <-- new
            "MSH": [
                "D012711",
                "D012711"
            ]
        },
        "canonical_name": "(131)I-Macroaggregated Albumin"
    },
```

This admittedly makes the JSON file a lot bigger.

Each dictionary value returns a **list** of `codes` for the key'd ontology (which likely includes duplicates). I took this approach because it seemed similar to your `aliases` field and allows for more processing downstream. A Counter dictionary would be another approach.

Open to suggestions.