### PR TITLE
Abbreviation fix

### DIFF
--- a/scispacy/abbreviation.py
+++ b/scispacy/abbreviation.py
@@ -116,6 +116,10 @@ def filter_matches(
 
 
 def short_form_filter(span: Span) -> bool:
+    # Below filters assume we actually have some text
+    if len(span.text) == 0:
+        return False
+
     # All words are between length 2 and 10
     if not all([2 <= len(x) < 10 for x in span]):
         return False

--- a/scispacy/abbreviation.py
+++ b/scispacy/abbreviation.py
@@ -89,8 +89,10 @@ def filter_matches(
     for match in matcher_output:
         start = match[1]
         end = match[2]
-        # Ignore spans with more than 8 words in.
-        if end - start > 8:
+        print(doc[start:end])
+        print(doc)
+        # Ignore spans with more than 8 words in them, and spans at the start of the doc
+        if end - start > 8 or start == 1:
             continue
         if end - start > 3:
             # Long form is inside the parens.
@@ -116,10 +118,6 @@ def filter_matches(
 
 
 def short_form_filter(span: Span) -> bool:
-    # Below filters assume we actually have some text
-    if len(span.text) == 0:
-        return False
-
     # All words are between length 2 and 10
     if not all([2 <= len(x) < 10 for x in span]):
         return False

--- a/scispacy/abbreviation.py
+++ b/scispacy/abbreviation.py
@@ -89,8 +89,6 @@ def filter_matches(
     for match in matcher_output:
         start = match[1]
         end = match[2]
-        print(doc[start:end])
-        print(doc)
         # Ignore spans with more than 8 words in them, and spans at the start of the doc
         if end - start > 8 or start == 1:
             continue

--- a/tests/test_abbreviation_detection.py
+++ b/tests/test_abbreviation_detection.py
@@ -165,15 +165,21 @@ class TestAbbreviationDetector(unittest.TestCase):
         doc2 = self.detector(doc)
         assert len(doc2._.abbreviations) == 0
 
-        @pytest.mark.xfail
-        def test_difficult_cases(self):
-            # Don't see an obvious way of solving these. They require something more semantic to distinguish
-            text = "is equivalent to (iv) of Theorem"
-            doc = self.nlp(text)
-            doc2 = self.detector(doc)
-            assert len(doc2._.abbreviations) == 0
+    def test_empty_span(self):
+        text = "(19, 9, 4) Hadamard Designs and Their Residual Designs"
+        doc = self.nlp(text)
+        doc2 = self.detector(doc)
+        assert len(doc2._.abbreviations) == 0
 
-            text = "or to fork.Users work more on their repositories (owners) than on"
-            doc = self.nlp(text)
-            doc2 = self.detector(doc)
-            assert len(doc2._.abbreviations) == 0
+    @pytest.mark.xfail
+    def test_difficult_cases(self):
+        # Don't see an obvious way of solving these. They require something more semantic to distinguish
+        text = "is equivalent to (iv) of Theorem"
+        doc = self.nlp(text)
+        doc2 = self.detector(doc)
+        assert len(doc2._.abbreviations) == 0
+
+        text = "or to fork.Users work more on their repositories (owners) than on"
+        doc = self.nlp(text)
+        doc2 = self.detector(doc)
+        assert len(doc2._.abbreviations) == 0


### PR DESCRIPTION
Code crashed if there were parens at the start of the doc, resulting in an empty short/long candidate