### PR TITLE
Create publish.yml

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -1,0 +1,29 @@
+# This workflow publishes the scispacy package (not the scispacy models) to pypi.
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    
+    if: github.repository == 'allenai/scispacy'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload -u scispacy -p ${{ secrets.PYPI_PASSWORD }} dist/*


### PR DESCRIPTION
This should allow us to publish directly to pypi whenever we create a release in the github ui, which should simplify publishing packages a lot. This way we just have to create the model packages and upload them, and create a release from master after we've merged a commit which updates the versions and paths etc.