### PR TITLE
update dockerfile python and debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.4-stretch
+FROM python:3.8-buster
 
 # install base packages
 RUN apt-get clean \


### PR DESCRIPTION
CI is failing because the python/debian combination in the Dockerfile doesn't have a wheel for the latest spacy, so its trying to build it or something. Seems reasonable to update to python 3.8 and latest stable debian anyway.

Should unblock #293 