### PR TITLE
Sort the candidates in entity linker.

### DIFF
--- a/scispacy/candidate_generation.py
+++ b/scispacy/candidate_generation.py
@@ -351,6 +351,7 @@ class CandidateGenerator:
                 MentionCandidate(concept, mentions, concept_to_similarities[concept])
                 for concept, mentions in concept_to_mentions.items()
             ]
+            mention_candidates = sorted(mention_candidates, key=lambda c: c.concept_id)
 
             batch_mention_candidates.append(mention_candidates)
 

--- a/tests/test_candidate_generation.py
+++ b/tests/test_candidate_generation.py
@@ -31,7 +31,7 @@ class TestCandidateGeneration(unittest.TestCase):
         results = candidate_generator(['(131)I-Macroaggregated Albumin'], 10)
 
         canonical_ids = [x.concept_id for x in results[0]]
-        assert canonical_ids == ['C0000005', 'C0000015', 'C0000102', 'C0000103', 'C0000074']
+        assert canonical_ids == ['C0000005', 'C0000015', 'C0000074', 'C0000102', 'C0000103']
 
         # The mention was an exact match, so should have a distance of zero to a concept:
         assert results[0][0] == MentionCandidate(concept_id='C0000005',


### PR DESCRIPTION
The order of candidates returned from the UMLS candidate generator could be different between retries, so that when different candidates have the same scores, entity linker could return different results for each retry because of the `max_entities_per_mention` limit.

This PR is to sort the candidates from the candidate generator, so that the entity linker returns consistent results between retries. 