### PR TITLE
Update spacy dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     license="Apache",
     install_requires=[
-        "spacy>=3.0.0,<3.1.0",
+        "spacy>=3.0.0,<3.2.0",
         "requests>=2.0.0,<3.0.0",
         "conllu",
         "numpy",


### PR DESCRIPTION
If we can get this done + release then scispacy=0.5.0 would be compatible with medspacy which it currently is not. Passes all tests so there shouldn't be any issues