### PR TITLE
Add a note about make_serializable argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ for abrv in doc._.abbreviations:
 >>> SBMA 	   	 (6, 7)     Spinal and bulbar muscular atrophy
 >>> AR   		 (29, 30)   androgen receptor
 ```
+
+> **Note**
+> If you want to be able to [serialize your `doc` objects](https://spacy.io/usage/saving-loading), load the abbreviation detector with `make_serializable=True`, e.g. `nlp.add_pipe("abbreviation_detector", config={"make_serializable": True})`
+
 ### EntityLinker
 
 The `EntityLinker` is a SpaCy component which performs linking to a knowledge base. The linker simply performs


### PR DESCRIPTION
By default the abbreviation detector pipe is not serializable, so you run into issues when you try to serialize any docs processed with it:

```python
from spacy.tokens import DocBin

nlp = spacy.load("en_core_sci_sm")
nlp.add_pipe("abbreviation_detector")

doc_bin = DocBin(store_user_data=True)
doc = nlp("Spinal and bulbar muscular atrophy (SBMA) is an inherited motor neuron disease caused by the expansion of a polyglutamine tract within the androgen receptor (AR). SBMA can be caused by this easily.")
doc_bin.add(doc)
# Throws an error: TypeError: can not serialize 'spacy.tokens.span.Span' object
```

It took me a while to figure out this is easily solved with the `make_serializable` parameter, but it's not documented anywhere so I am proposing to add a short note in the readme about it.