### PR TITLE
Fixes #485 Project Page URL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("scispacy/version.py", "r") as version_file:
 setup(
     name="scispacy",
     version=VERSION["VERSION"],
-    url="https://allenai.github.io/SciSpaCy/",
+    url="https://github.com/allenai/scispacy",
     author="Allen Institute for Artificial Intelligence",
     author_email="ai2-info@allenai.org",
     description="A full SpaCy pipeline and models for scientific/biomedical documents.",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("scispacy/version.py", "r") as version_file:
 setup(
     name="scispacy",
     version=VERSION["VERSION"],
-    url="https://github.com/allenai/scispacy",
+    url="https://allenai.github.io/scispacy/",
     author="Allen Institute for Artificial Intelligence",
     author_email="ai2-info@allenai.org",
     description="A full SpaCy pipeline and models for scientific/biomedical documents.",


### PR DESCRIPTION
The project URL in the setup.py seems to be outdated. It's updated with the latest URL.