### PR TITLE
add progress bar to http_get

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("scispacy/version.py", "r") as version_file:
 setup(
     name="scispacy",
     version=VERSION["VERSION"],
-    url="https://allenai.github.io/SciSpaCy/",
+    url="https://allenai.github.io/scispacy/",
     author="Allen Institute for Artificial Intelligence",
     author_email="ai2-info@allenai.org",
     description="A full SpaCy pipeline and models for scientific/biomedical documents.",


### PR DESCRIPTION
I have discussed with the maintainer in [issue-490](https://github.com/allenai/scispacy/issues/490), and encouraged to raise this PR.

**Gist**:
To use scispacy, some of the resources are fetched from web url, e.g. [URL of tfidf_vectors_sparse](https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/data/linkers/2023-04-23/umls/tfidf_vectors_sparse.npz). And the size of the resources could be up to 500M, thereby taking several miutes to complete downloading. Somehow scispacy download quietly without signals for users, so thet can't tell whether the progress stucks or not.

So I add a progress bar to the function `http_get` to let users know where they are.
![](https://user-images.githubusercontent.com/43513739/259541705-bb50e4a0-966f-40f5-a837-3326639eeed6.png)

Scispacy helps me a lot in my research, thanks for your contribution to our community. And thanks for your review.