### PR TITLE
Support Python 3.12 via newer scipy and nmslib-metabrainz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /work
 COPY requirements.in .
 
 RUN pip install -r requirements.in
-RUN pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.3/en_core_sci_sm-0.5.3.tar.gz
+RUN pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz
 RUN python -m spacy download en_core_web_sm
 RUN python -m spacy download en_core_web_md
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,9 @@
 numpy
-scipy<1.11
+# NOTE: scipy<1.11 is required when creating the linkers, so that's currently
+# only supported on Python<3.11
+# https://github.com/allenai/scispacy/issues/519#issuecomment-2229915999
+scipy<1.11; python_version < '3.11'
+scipy; python_version >= '3.11'
 spacy>=3.7.0,<3.8.0
 spacy-lookups-data
 pandas
@@ -8,7 +12,10 @@ conllu
 
 # Candidate generation and entity linking
 joblib
-nmslib>=1.7.3.6
+nmslib>=1.7.3.6; python_version < '3.11'
+# Use the metabrainz fork until nmslib supports installing on Python 3.11+
+# https://github.com/nmslib/nmslib/issues/555
+nmslib-metabrainz>=2.1.3; python_version >= '3.11'
 scikit-learn>=0.20.3
 
 # Required for testing.

--- a/scispacy/candidate_generation.py
+++ b/scispacy/candidate_generation.py
@@ -10,6 +10,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 import nmslib
 from nmslib.dist import FloatIndex
 
+from scispacy.util import scipy_supports_sparse_float16
 from scispacy.file_cache import cached_path
 from scispacy.linking_utils import (
     KnowledgeBase,
@@ -375,6 +376,9 @@ def create_tfidf_ann_index(
         The kb items to generate the index and vectors for.
 
     """
+    if not scipy_supports_sparse_float16():
+        raise RuntimeError("This function requires an older version of scipy.")
+
     tfidf_vectorizer_path = f"{out_path}/tfidf_vectorizer.joblib"
     ann_index_path = f"{out_path}/nmslib_index.bin"
     tfidf_vectors_path = f"{out_path}/tfidf_vectors_sparse.npz"

--- a/scispacy/util.py
+++ b/scispacy/util.py
@@ -1,4 +1,6 @@
+from packaging.version import Version
 import spacy
+import scipy
 from spacy.language import Language
 from spacy.tokens import Doc
 
@@ -15,6 +17,11 @@ def create_combined_rule_model() -> Language:
     nlp.tokenizer = combined_rule_tokenizer(nlp)
     nlp.add_pipe(pysbd_sentencizer, first=True)
     return nlp
+
+
+def scipy_supports_sparse_float16() -> bool:
+    # https://github.com/scipy/scipy/issues/7408
+    return Version(scipy.__version__) < Version('1.11')
 
 
 class WhitespaceTokenizer:

--- a/tests/test_candidate_generation.py
+++ b/tests/test_candidate_generation.py
@@ -3,9 +3,16 @@ import tempfile
 
 from scispacy.candidate_generation import CandidateGenerator, create_tfidf_ann_index, MentionCandidate
 from scispacy.umls_utils import UmlsKnowledgeBase
+from scispacy.util import scipy_supports_sparse_float16
 
 
 class TestCandidateGeneration(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        if not scipy_supports_sparse_float16():
+            # https://github.com/allenai/scispacy/issues/519#issuecomment-2229915999
+            self.skipTest("Candidate generation isn't supported for scipy>=1.11")
 
     def test_create_index(self):
 

--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -7,11 +7,16 @@ from scispacy.candidate_generation import CandidateGenerator, create_tfidf_ann_i
 from scispacy.linking import EntityLinker
 from scispacy.umls_utils import UmlsKnowledgeBase
 from scispacy.abbreviation import AbbreviationDetector
+from scispacy.util import scipy_supports_sparse_float16
 
 
 class TestLinker(unittest.TestCase):
     def setUp(self):
         super().setUp()
+        if not scipy_supports_sparse_float16():
+            # https://github.com/allenai/scispacy/issues/519#issuecomment-2229915999
+            self.skipTest("Candidate generation isn't supported for scipy>=1.11")
+
         self.nlp = spacy.load("en_core_web_sm")
 
         umls_fixture = UmlsKnowledgeBase("tests/fixtures/umls_test_fixture.json", "tests/fixtures/test_umls_tree.tsv")


### PR DESCRIPTION
- Allows for installing scipy>=1.11 when Python version >= 3.11, but this prevents testing and running the code that generates the linkers.
- Depends on nmslib-metabrainz rather than nmslib for newer Python versions, since the latter hasn't yet incorporated support for Python 3.11+.
- Upgrades the scispacy model in the Dockerfile to 0.5.4, so the steps in the Dockerfile will run correctly on Python 3.12.

I don't have any strong opinions on the small decisions made here (e.g. should we install latest scipy by default when Python<3.11?), just trying to get something that will install on Python 3.12.  Happy to revise as desired.