### PR TITLE
Add shorter version of pip installing nmslib from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Over the years, installing nmslib has becomes quite difficult. There are a numbe
 Other methods mentioned in GitHub issues, but unconfirmed what versions they work for:
 - `CFLAGS="-mavx -DWARN(a)=(a)" pip install nmslib`
 - `pip install --no-binary :all: nmslib`
+- `pip install "nmslib @ git+https://github.com/nmslib/nmslib.git/#subdirectory=python_bindings"`
 - `pip install --upgrade pybind11` + `pip install --verbose 'nmslib @ git+https://github.com/nmslib/nmslib.git#egg=nmslib&subdirectory=python_bindings'`
 
 #### Setting up a virtual environment


### PR DESCRIPTION
Adding to the docs on alternatives to install `mslib`, I thought it would be useful to add the shorter variant
```
pip install "nmslib @ git+https://github.com/nmslib/nmslib.git/#subdirectory=python_bindings"
```
as taken from https://github.com/allenai/scispacy/issues/473#issuecomment-1590443024. Works for me on Windows 10 & Python 3.10.