### PR TITLE
Document extending scispaCy with additional ontologies with PyOBO

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ rows = [
         span,
         span.start_char,
         span.end_char,
-        f"`{identifier} <https://bioregistry.io/{identifier}>`_",
+        f"[{identifier}](https://bioregistry.io/{identifier})",
         score,
     )
     for span in doc.ents

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ print(doc._.hearst_patterns)
 Arbitrary databases and ontologies can be loaded into scispaCy using the
 external integration with [pyobo](https://github.com/biopragmatics/pyobo) following
 `pip install "pyobo>=0.12.9"`. In the following example, the HGNC database
-is loaded used to link genes to standard identifiers.
+is used to link genes to standard identifiers.
 
 ```python
 import pyobo

--- a/README.md
+++ b/README.md
@@ -293,8 +293,48 @@ print(doc._.hearst_patterns)
 #### PyOBO Integration
 
 Arbitrary databases and ontologies can be loaded into SciSpacy using the
-external integration with [pyobo](https://github.com/biopragmatics/pyobo).
-See [the tutorial](https://pyobo.readthedocs.io/en/latest/scispacy.html).
+external integration with [pyobo](https://github.com/biopragmatics/pyobo) after
+`pip install "pyobo>=0.12.9"`.
+
+```python
+import pyobo
+import spacy
+from scispacy.linking import EntityLinker
+from tabulate import tabulate
+
+linker: EntityLinker = pyobo.get_scispacy_entity_linker("hgnc", filter_for_definitions=False)
+
+# now, put it all together with a NER model
+nlp = spacy.load("en_core_web_sm")
+
+text = (
+    "RAC(Rho family)-alpha serine/threonine-protein kinase "
+    "is an enzyme that in humans is encoded by the AKT1 gene."
+)
+doc = linker(nlp(text))
+
+rows = [
+    (
+        span,
+        span.start_char,
+        span.end_char,
+        f"`{curie} <https://bioregistry.io/{curie}>`_",
+        score,
+    )
+    for span in doc.ents
+    for curie, score in span._.kb_ents
+]
+print(tabulate(rows, headers=["text", "start", "end", "prefix", "identifier"], tablefmt="github"))
+```
+
+| text | start | end | curie                                       |    score |
+| ---- | ----- | --- | ------------------------------------------- | -------: |
+| AKT1 | 100   | 104 | [hgnc:391](https://bioregistry.io/hgnc:391) |        1 |
+| AKT1 | 100   | 104 | [hgnc:392](https://bioregistry.io/hgnc:392) | 0.776504 |
+| AKT1 | 100   | 104 | [hgnc:393](https://bioregistry.io/hgnc:393) | 0.764049 |
+
+For more information, see
+[the tutorial](https://pyobo.readthedocs.io/en/latest/scispacy.html).
 
 
 ## Citing

--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ print(doc._.hearst_patterns)
 >>> [('such_as', Keystone plant species, fig trees)]
 ```
 
+#### PyOBO Integration
+
+Arbitrary databases and ontologies can be loaded into SciSpacy using the
+external integration with [pyobo](https://github.com/biopragmatics/pyobo).
+See [the tutorial](https://pyobo.readthedocs.io/en/latest/scispacy.html).
+
 
 ## Citing
 

--- a/README.md
+++ b/README.md
@@ -290,11 +290,12 @@ print(doc._.hearst_patterns)
 >>> [('such_as', Keystone plant species, fig trees)]
 ```
 
-#### PyOBO Integration
+## Extending scispaCy to new databases and ontologies
 
-Arbitrary databases and ontologies can be loaded into SciSpacy using the
-external integration with [pyobo](https://github.com/biopragmatics/pyobo) after
-`pip install "pyobo>=0.12.9"`.
+Arbitrary databases and ontologies can be loaded into scispaCy using the
+external integration with [pyobo](https://github.com/biopragmatics/pyobo) following
+`pip install "pyobo>=0.12.9"`. In the following example, the HGNC database
+is loaded used to link genes to standard identifiers.
 
 ```python
 import pyobo
@@ -318,17 +319,17 @@ rows = [
         span,
         span.start_char,
         span.end_char,
-        f"`{curie} <https://bioregistry.io/{curie}>`_",
+        f"`{identifier} <https://bioregistry.io/{identifier}>`_",
         score,
     )
     for span in doc.ents
-    for curie, score in span._.kb_ents
+    for identifier, score in span._.kb_ents
 ]
 print(tabulate(rows, headers=["text", "start", "end", "prefix", "identifier"], tablefmt="github"))
 ```
 
-| text | start | end | curie                                       |    score |
-| ---- | ----- | --- | ------------------------------------------- | -------: |
+| text | start | end | identifier                                  |    score |
+| ---- | ----- | --- |---------------------------------------------| -------: |
 | AKT1 | 100   | 104 | [hgnc:391](https://bioregistry.io/hgnc:391) |        1 |
 | AKT1 | 100   | 104 | [hgnc:392](https://bioregistry.io/hgnc:392) | 0.776504 |
 | AKT1 | 100   | 104 | [hgnc:393](https://bioregistry.io/hgnc:393) | 0.764049 |


### PR DESCRIPTION
Following these improvements in scispaCy:

- https://github.com/allenai/scispacy/pull/544
- https://github.com/allenai/scispacy/pull/547
- https://github.com/allenai/scispacy/pull/549
- https://github.com/biopragmatics/pyobo/pull/437

This PR adds documentation on to the README to showcase how arbitrary ontologies and databases can be loaded for use as a scispaCy entity linker via PyOBO. It does this by:

1. Adding an end-to-end example for annotating genes using HGNC
2. Adds a link to more example usage in the PyOBO docs at https://pyobo.readthedocs.io/en/latest/scispacy.html


This also closes #331. `hgnc` can be replaced with `to` to use the Plant Trait Ontology, however I wasn't able to construct a convincing use case, so that can be left to the issue submitter.