### PR TITLE
Refactor KnowledgeBase constructor

### DIFF
--- a/scispacy/linking_utils.py
+++ b/scispacy/linking_utils.py
@@ -128,8 +128,7 @@ def _index_entities(
     cui_to_entity: Dict[str, Entity] = {}
     alias_to_cuis: DefaultDict[str, Set[str]] = defaultdict(set)
     for entity in entities:
-        alias_to_cuis[entity.canonical_name].add(entity.concept_id)
-        for alias in entity.aliases:
+        for alias in set(entity.aliases + [entity.canonical_name]):
             alias_to_cuis[alias].add(entity.concept_id)
         cui_to_entity[entity.concept_id] = entity
     return cui_to_entity, dict(alias_to_cuis)

--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -5,6 +5,7 @@ import spacy
 
 from scispacy.candidate_generation import CandidateGenerator, create_tfidf_ann_index
 from scispacy.linking import EntityLinker
+from scispacy.linking_utils import Entity, KnowledgeBase, _iter_entities
 from scispacy.umls_utils import UmlsKnowledgeBase
 from scispacy.abbreviation import AbbreviationDetector
 from scispacy.util import scipy_supports_sparse_float16
@@ -23,32 +24,41 @@ class TestLinker(unittest.TestCase):
         self.linker = EntityLinker.from_kb(umls_fixture, filter_for_definitions=False)
 
     def test_naive_entity_linking(self):
+        self._test_linker(self.linker)
+
+    def test_custom_loading(self):
+        with _iter_entities("tests/fixtures/umls_test_fixture.json") as entities:
+            kb = UmlsKnowledgeBase(entities,"tests/fixtures/test_umls_tree.tsv")
+        linker = EntityLinker.from_kb(kb, filter_for_definitions=False)
+        self._test_linker(linker)
+
+    def _test_linker(self, linker: EntityLinker) -> None:
         text = "There was a lot of Dipalmitoylphosphatidylcholine."
         doc = self.nlp(text)
 
         # Check that the linker returns nothing if we set the filter_for_definitions flag
         # and set the threshold very high for entities without definitions.
-        self.linker.filter_for_definitions = True
-        self.linker.no_definition_threshold = 3.0
-        doc = self.linker(doc)
+        linker.filter_for_definitions = True
+        linker.no_definition_threshold = 3.0
+        doc = linker(doc)
         assert doc.ents[0]._.kb_ents == []
 
         # Check that the linker returns only high confidence entities if we
         # set the threshold to something more reasonable.
-        self.linker.no_definition_threshold = 0.95
-        doc = self.linker(doc)
+        linker.no_definition_threshold = 0.95
+        doc = linker(doc)
         assert doc.ents[0]._.kb_ents == [("C0000039", 1.0)]
 
-        self.linker.filter_for_definitions = False
-        self.linker.threshold = 0.45
-        doc = self.linker(doc)
+        linker.filter_for_definitions = False
+        linker.threshold = 0.45
+        doc = linker(doc)
         # Without the filter_for_definitions filter, we get 2 entities for
         # the first mention.
         assert len(doc.ents[0]._.kb_ents) == 2
 
         id_with_score = doc.ents[0]._.kb_ents[0]
         assert id_with_score == ("C0000039", 1.0)
-        umls_entity = self.linker.kb.cui_to_entity[id_with_score[0]]
+        umls_entity = linker.kb.cui_to_entity[id_with_score[0]]
         assert umls_entity.concept_id == "C0000039"
         assert umls_entity.types == ["T109", "T121"]
 


### PR DESCRIPTION
This PR refactors the constructor of the `KnowledgeBase` class to extend it in two ways:

1. Enable passing a `Path` object (in addition to a string)
2. Enable passing any iterable (e.g., a list) of `Entity` objects

This will enable making custom KB objects, such as using Wikidata (as requested in https://github.com/allenai/scispacy/issues/346) or using biomedical ontologies (as requested in https://github.com/allenai/scispacy/issues/331)

This PR was originally part of #542, but that PR had too many things going on, so I split out this part to be simpler to review.

Corresponding PR in my fork (for testing purposes, because I can't run CI on the upstream): https://github.com/cthoyt/scispacy/pull/8