### PR TITLE
Construct a KnowledgeBase from a Wikidata Query

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "nmslib-metabrainz==2.1.3; python_version >= '3.10'",
     "scikit-learn>=0.20.3",
     "pysbd",
+    "typing-extensions",
 ]
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
@@ -66,6 +67,7 @@ tests = [
     "black",
     "mypy",
     "types-requests",
+    "wikidata-client",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This PR is a spin-off from #542 that addresses https://github.com/allenai/scispacy/issues/346.

This PR adds a utility function for constructing a knowledge base from a SPARQL query to Wikidata (requires `pip install wikidata-client`) with the following:

```python
from scispacy.linking_utils import KnowledgeBase

# this SPARQL query gets named cats
sparql = """
SELECT ?item ?itemLabel ?itemDescription ?itemAltLabel
WHERE {
    ?item wdt:P31 wd:Q146. # Must be a cat
    SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
}
"""

kb = KnowledgeBase.from_wikidata(sparql, "item")
```